### PR TITLE
Fix links to twig.symfony.com

### DIFF
--- a/samples/for.1.json
+++ b/samples/for.1.json
@@ -7,7 +7,7 @@
     },
     "templates": [{
             "filename": "main.twig",
-            "content": "{#\n # Twig for\n # http:\/\/twig.sensiolabs.org\/doc\/tags\/for.html\n #\n # for tag let you iterate throught an array, an object or whatever\n #}\n \n \nSimple loop:\n\n{% for key, value in array %}\n  {{ key }} = {{ value }}\n{% endfor %}\n \n \nLoop between 10 and 20:\n\n{% for number in 10..20 %}\n  num = {{ number }}\n{% endfor %}\n\n\nLoop with a condition\n\n{% for number in 10..20 if number is even %}\n  num = {{ number }}\n{% endfor %}",
+            "content": "{#\n # Twig for\n # https:\/\/twig.symfony.com\/doc\/tags\/for.html\n #\n # for tag let you iterate throught an array, an object or whatever\n #}\n \n \nSimple loop:\n\n{% for key, value in array %}\n  {{ key }} = {{ value }}\n{% endfor %}\n \n \nLoop between 10 and 20:\n\n{% for number in 10..20 %}\n  num = {{ number }}\n{% endfor %}\n\n\nLoop with a condition\n\n{% for number in 10..20 if number is even %}\n  num = {{ number }}\n{% endfor %}",
             "main": true
         }],
     "twig_engine": "Twig 1.x",

--- a/samples/if.1.json
+++ b/samples/if.1.json
@@ -7,7 +7,7 @@
     },
     "templates": [{
             "filename": "main.twig",
-            "content": "{#\n # Twig macros\n # http:\/\/twig.sensiolabs.org\/doc\/tags\/if.html\n #\n # Execute code only if a condition evaluates to true\n #}\n\nA test that passes:\n\n{% if true %}\n  Success!\n{% endif %}\n\nA test that fails:\n\n{% if false %}\n  Failed!\n{% endif %}\n\nA negative test:\n\n{% if not false %}\n  So that's true!\n{% endif %}\n\nIf, elseif, else, endif:\n\n{% if kenny.sick %}\n  Kenny is sick.\n{% elseif kenny.dead %}\n  You killed Kenny! You bastard!!!\n{% else %}\n  Kenny looks okay --- so far\n{% endif %}",
+            "content": "{#\n # Twig macros\n # https:\/\/twig.symfony.com\/doc\/tags\/if.html\n #\n # Execute code only if a condition evaluates to true\n #}\n\nA test that passes:\n\n{% if true %}\n  Success!\n{% endif %}\n\nA test that fails:\n\n{% if false %}\n  Failed!\n{% endif %}\n\nA negative test:\n\n{% if not false %}\n  So that's true!\n{% endif %}\n\nIf, elseif, else, endif:\n\n{% if kenny.sick %}\n  Kenny is sick.\n{% elseif kenny.dead %}\n  You killed Kenny! You bastard!!!\n{% else %}\n  Kenny looks okay --- so far\n{% endif %}",
             "main": true
         }],
     "twig_engine": "Twig 1.x",

--- a/samples/macro.1.json
+++ b/samples/macro.1.json
@@ -6,7 +6,7 @@
     },
     "templates": [{
             "filename": "main.twig",
-            "content": "{#\n # Twig macros\n # http:\/\/twig.sensiolabs.org\/doc\/tags\/macro.html\n #\n # Macros can be compared to functions in other languages\n #}\n\nMacros defined in the current file:\n\n{% macro blue(string) %}\n\n  <p style=\"color: blue;\">{{ string }}<\/p>\n\n{% endmacro %}\n\n{{ _self.blue('I am blue') }}\n\nImport a macro file:\n\n{% import 'macros.twig' as macros %}\n{{ macros.red('I am red') }}\n\nImport only one macro from a file:\n\n{% from 'lots-of-macros.twig' import green %}\n{{ green('I am green') }}",
+            "content": "{#\n # Twig macros\n # https:\/\/twig.symfony.com\/doc\/tags\/macro.html\n #\n # Macros can be compared to functions in other languages\n #}\n\nMacros defined in the current file:\n\n{% macro blue(string) %}\n\n  <p style=\"color: blue;\">{{ string }}<\/p>\n\n{% endmacro %}\n\n{{ _self.blue('I am blue') }}\n\nImport a macro file:\n\n{% import 'macros.twig' as macros %}\n{{ macros.red('I am red') }}\n\nImport only one macro from a file:\n\n{% from 'lots-of-macros.twig' import green %}\n{{ green('I am green') }}",
             "main": true
         }, {
             "filename": "macros.twig",

--- a/samples/verbatim.1.json
+++ b/samples/verbatim.1.json
@@ -6,7 +6,7 @@
     },
     "templates": [{
             "filename": "main.twig",
-            "content": "{#\n # Twig verbatim\n # http:\/\/twig.sensiolabs.org\/doc\/tags\/verbatim.html\n #\n # Verbatim let you write twig code inside twig files\n #}\n \nTo loop over an array in Twig, you should use:\n \n{% verbatim %}\n \n{% for key, value in array %}\n   {{ key }} = {{ value }}\n{% endfor %}\n \n{% endverbatim %}",
+            "content": "{#\n # Twig verbatim\n # https:\/\/twig.symfony.com\/doc\/tags\/verbatim.html\n #\n # Verbatim let you write twig code inside twig files\n #}\n \nTo loop over an array in Twig, you should use:\n \n{% verbatim %}\n \n{% for key, value in array %}\n   {{ key }} = {{ value }}\n{% endfor %}\n \n{% endverbatim %}",
             "main": true
         }],
     "twig_engine": "Twig 1.x",

--- a/web/src/Fuz/AppBundle/Resources/views/Article/about/introduction.html.twig
+++ b/web/src/Fuz/AppBundle/Resources/views/Article/about/introduction.html.twig
@@ -16,9 +16,8 @@
             <div class="h2"><strong>About twigfiddle.com</strong></div>
             <div>
                 <p>
-                    Twig (<a href="http://twig.sensiolabs.org" target="_blank">http://twig.sensiolabs.org</a>) is a modern template engine for PHP,
-                    based on Django and Jinja syntaxes. It is an opensource product, released under the new BSD license
-                    (<a href="http://twig.sensiolabs.org/license" target="_blank">http://twig.sensiolabs.org/license</a>) by Fabien Potencier.
+                    <a href="https://twig.symfony.com" target="_blank">Twig </a> is a modern template engine for PHP, based on Django and Jinja syntaxes.
+                    It is an opensource product, released under the <a href="https://twig.symfony.com/license" target="_blank">3-Clause BSD License</a> by Fabien Potencier.
                 </p>
 
                 <p>

--- a/web/src/Fuz/AppBundle/Resources/views/Article/about/special-thanks.html.twig
+++ b/web/src/Fuz/AppBundle/Resources/views/Article/about/special-thanks.html.twig
@@ -40,7 +40,7 @@
             <br/>
             <li>
                 Thank you <a href="https://github.com/fabpot" target="_blank">Fabien Potencier</a> and
-                <a href="http://twig.sensiolabs.org/contributors" target="_blank">the whole Twig community</a> for building such awesome
+                <a href="https://twig.symfony.com/contributors" target="_blank">the whole Twig community</a> for building such awesome
                 piece of code for free.
             </li>
             <br/>

--- a/web/src/Fuz/AppBundle/Resources/views/Fiddle/options.html.twig
+++ b/web/src/Fuz/AppBundle/Resources/views/Fiddle/options.html.twig
@@ -45,7 +45,7 @@
         <div class="control-group">
             <label class="control-label" for="selectbasic">
                 Enable non-native Twig extensions
-                (<a class="dark" href="http://twig.sensiolabs.org/doc/extensions/index.html" target="_blank">read more</a>)
+                (<a class="dark" href="https://twig.symfony.com/doc/extensions/index.html" target="_blank">read more</a>)
             </label>
             <div class="controls">
                 {{ form_widget(form.twigExtension) }}
@@ -62,7 +62,7 @@
                 <div class="form-control">
                     <label for="{{ form.withStrictVariables.vars.id }}">
                         Enable Strict Variables mode
-                        (<a class="dark" href="http://twig.sensiolabs.org/doc/templates.html#variables" target="_blank">read more</a>)
+                        (<a class="dark" href="https://twig.symfony.com/doc/templates.html#variables" target="_blank">read more</a>)
                     </label>
                 </div>
             </div>


### PR DESCRIPTION
Twig's website moved to https://twig.symfony.com and `twig.sensiolabs.org` is not redirecting anymore.